### PR TITLE
chore: линтовать репозиторий целиком, а не список каталогов

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	@uv sync
 
 lint:
-	@uv run ruff check src test
+	@uv run ruff check .
 
 test:
 	@uv run pytest test


### PR DESCRIPTION
Список каталогов в цели `lint` молча пропускает файлы вне него. Единый вид у всех четырёх python-библиотек пачки (`docs/components-modernization.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)