### PR TITLE
chore: гонять примеры из README, а не обещать это комментарием

### DIFF
--- a/.github/workflows/pyci.yml
+++ b/.github/workflows/pyci.yml
@@ -25,3 +25,5 @@ jobs:
         run: make lint
       - name: Run tests
         run: make test
+      - name: Run doctests
+        run: make doctest

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ lint:
 test:
 	@uv run pytest test
 
-check: install lint test
+doctest:
+	@uv run pytest --doctest-glob='*.md' README.md
+
+check: install lint test doctest
 
 build:
 	@uv build
@@ -17,4 +20,4 @@ build:
 publish: build
 	@uv publish --trusted-publishing always
 
-.PHONY: install lint test check build publish
+.PHONY: install lint test doctest check build publish

--- a/README.md
+++ b/README.md
@@ -12,14 +12,19 @@ pip install hexlet-pairs
 
 ## Usage
 
-<!-- This code will be doctested. Do not touch the markup! -->
+```python
+>>> from hexlet import pairs
+>>> p = pairs.cons(42, 'foo')
+>>> pairs.is_pair(p)
+True
+>>> pairs.car(p)
+42
+>>> pairs.cdr(p)
+'foo'
+>>> print(pairs.to_string(p))
+cons(42, 'foo')
 
-    from hexlet import pairs
-    p = pairs.cons(42, 'foo')
-    pairs.is_pair(p)  # True
-    pairs.car(p)  # 42
-    pairs.cdr(p)  # 'foo'
-    print(pairs.to_string(p))  # cons(42, 'foo')
+```
 
 ---
 


### PR DESCRIPTION
В README стоял комментарий `This code will be doctested. Do not touch the markup!`, но доктеста не было ни в `Makefile`, ни в CI, а разметка была не доктестовой: отступ вместо `>>>` и ожидаемые значения в комментариях. Примеры не проверялись ничем и могли молча разойтись с кодом.

Блок переписан в настоящий doctest, добавлены цель `make doctest` и шаг в CI. Локально зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)