### PR TITLE
fix: искать релизные теги в том виде, в каком они есть

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "hexlet-pairs"
+      "package-name": "hexlet-pairs",
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
В манифест-режиме release-please по умолчанию ищет тег вида `<package-name>-v1.2.3`, а теги в репозитории обычные: `v1.2.3`. Не найдя своего тега, он считает, что релизов не было, и пересобирает версию по всей истории.

Поймано на `python-pairs`: релизный PR предлагал 0.1.3 на основании `docs(readme)`-коммита многолетней давности. Поправлено во всех четырёх python-библиотеках разом, чтобы теги остались единообразными с остальной организацией.

🤖 Generated with [Claude Code](https://claude.com/claude-code)